### PR TITLE
Fix critical method name bug in advanced_web.py

### DIFF
--- a/aruco_generator/advanced_web.py
+++ b/aruco_generator/advanced_web.py
@@ -66,7 +66,7 @@ def advanced_preview():
                     y=marker['y'] - 2
                 )
 
-        svg_content = ctx.to_svg()
+        svg_content = ctx.get_svg()
         total_width, total_height = aruco_gen.calculate_total_size(
             rows=rows,
             cols=cols,


### PR DESCRIPTION
## 🐛 Bug Fix: Critical Method Name Correction

### Problem
The `advanced_web.py` file on line 69 was calling `ctx.to_svg()` but the `DrawingContext` class only has a `get_svg()` method. This was causing an `AttributeError` that broke SVG export functionality.

### Solution
- **Fixed**: `ctx.to_svg()` → `ctx.get_svg()` on line 69
- **Root Cause**: Method name mismatch between caller and available method
- **Impact**: Restores SVG export functionality in advanced web interface

### Testing
✅ **Comprehensive Testing Completed:**
- Verified `DrawingContext` class has `get_svg()` method (not `to_svg()`)
- Tested SVG generation with single and multiple markers
- Confirmed no regressions in core ArUCO generation functionality
- Validated fix works with realistic web endpoint parameters

### Changes
- **File**: `aruco_generator/advanced_web.py`
- **Line**: 69
- **Change**: Single method name correction
- **Risk**: Minimal - isolated fix with comprehensive testing

### Verification
```python
# Before (broken):
svg_content = ctx.to_svg()  # AttributeError: 'DrawingContext' object has no attribute 'to_svg'

# After (working):
svg_content = ctx.get_svg()  # ✅ Works correctly
```

This is a critical fix that restores essential export functionality with zero risk of regression.

@Reece-Challinor can click here to [continue refining the PR](https://app.all-hands.dev/conversations/8c2c5ec3a60c479fba14e85bf980f0c5)